### PR TITLE
manage nested subvolumes

### DIFF
--- a/lib/puppet/provider/subvolume/btrfs.rb
+++ b/lib/puppet/provider/subvolume/btrfs.rb
@@ -16,9 +16,8 @@ Puppet::Type.type(:subvolume).provide(:btrfs) do
     matched = /^(.*)\/(.*?)$/.match(@resource[:path])
     filesys = matched[1]
     subvol = matched[2]
-
-    #TODO: this should also support nested subvolumes:
-    if btrfscmd(:subvolume, :list, filesys).split("\n").detect { |line| line.split("\s")[-1] == subvol }
+# Ensure the line ends with the subvolume we want to create (and handle nested subvolumes)
+    if btrfscmd(:subvolume, :list, filesys).split("\n").detect { |line| line.split("\s")[-1] =~ /.*#{subvol}$/ }
       true
     else
       false


### PR DESCRIPTION
In some case you may have sub volumes whose parent folder is not a btrfs (sub)volume, i.e.:
(assuming / is a btrfs volume)
# btrfs su li /mnt/

ID 293 gen 34693 top level 5 path mnt/subvol
ID 295 gen 34681 top level 293 path mnt/subvol/subvol2

 btrfs su li /mnt/subvol/
ID 293 gen 34693 top level 5 path mnt/subvol
ID 295 gen 34681 top level 293 path subvol2

The initial check would fail while trying to create /mnt/subvol.
